### PR TITLE
fix: tx dots for bad time ranges

### DIFF
--- a/apps/web-ui/src/components/graphs/graph-utils.ts
+++ b/apps/web-ui/src/components/graphs/graph-utils.ts
@@ -145,6 +145,16 @@ export const rangeToDays = (range: IChartTimeFrameRange) => {
   throw new Error("invalid range for rangeToDays");
 };
 
+export const getRangeFromTime = (time: number) => {
+  if (time <= 1000 * 60 * 60 * 24) {
+    return "1D";
+  } else if (time <= 1000 * 60 * 60 * 24 * 7) {
+    return "1W";
+  }
+
+  return "1M";
+};
+
 export const getDatesForChartGroup = (
   start: Date,
   end: Date,

--- a/apps/web-ui/src/lib/hooks/useChartData.ts
+++ b/apps/web-ui/src/lib/hooks/useChartData.ts
@@ -15,6 +15,7 @@ import {
   getGroupKey,
   addTime,
   getDatesForChartGroup,
+  getRangeFromTime,
 } from "@components/graphs/graph-utils";
 
 type IUseChartData = {
@@ -115,6 +116,24 @@ export const useChartData = (opts: IUseChartData) => {
   }
 
   chartTimeframeGroup = chartTimeFrameGroupRef.current;
+
+  // if the time difference between last two prices and first
+  // two prices is different, it means that the range needs
+  // to be set on the first because we dont have the data
+  // for the last price (which is probably smaller)
+  if (prices.length > 4) {
+    const [firstDate] = prices[0];
+    const [secondDate] = prices[1];
+    const firstDiff = secondDate - firstDate;
+
+    const [sendToLastDate] = prices[prices.length - 2];
+    const [lastDate] = prices[prices.length - 1];
+    const lastDiff = lastDate - sendToLastDate;
+    if (lastDiff !== firstDiff) {
+      const range = getRangeFromTime(firstDiff);
+      chartTimeframeGroup = range;
+    }
+  }
 
   const selectedTxs =
     AppContext.useSelector((current) => {


### PR DESCRIPTION
when the price range has bad data (new installs have difference in ranges. this is because historically only daily data is loaded into the db. however it then collects data every 5 minutes so hourly data could be different for range of 3m for example. the later dates could have hourly but the first dates dont).