### PR TITLE
Chore/changelog fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,6 +131,9 @@ jobs:
         run: |
           npx nx run web-ui-e2e:e2e-ci
 
+      # create a way to update the commitSha from the release
+      # so we can use the commit from the release to point commitSha
+      # also allow tags to be updated
       - name: WebshotArchive Action
         uses: toshimoto821/toshi-action@images
         env:
@@ -153,6 +156,7 @@ jobs:
         run: npx nx affected --target=version --exclude='*,!tag:deployable' --base=$BASE --head=$HEAD
         env:
           SHA: ${{ env.HEAD }}
+          projectId: ${{ secrets.TIMECHAIN_PROJECT_ID }}
           # todo change this image path to use branch
           FILES: |
             https://api.webshotarchive.com/api/image/path/dist/cypress/apps/web-ui-e2e/screenshots/app.cy.ts/web-ui-e2e%20--%20Hero.png?commitSha=${{ env.HEAD }}&projectId=${{secrets.TIMECHAIN_PROJECT_ID}}

--- a/packages/scripts/src/lib/util/injectImagesToChangelog.ts
+++ b/packages/scripts/src/lib/util/injectImagesToChangelog.ts
@@ -167,6 +167,7 @@ export async function injectImagesToChangelog(
     const newCommit = await getLastTag();
     if (newCommit.commit) {
       await addTag(newCommit.commit, lastTag.tags);
+      return newCommit.commit;
     } else {
       console.error("did not find a commit to tag");
     }

--- a/packages/scripts/src/lib/util/updateImagesForProject.ts
+++ b/packages/scripts/src/lib/util/updateImagesForProject.ts
@@ -1,0 +1,30 @@
+import axios from "axios";
+
+interface IUpdateImagesForProjectOpts {
+  find: {
+    commitSha: string;
+  };
+  update: {
+    commitSha: string;
+    tags: string[];
+  };
+}
+
+export const updateImagesForProject = async (
+  projectId: string,
+  opts: IUpdateImagesForProjectOpts
+) => {
+  const { find, update } = opts;
+  
+
+  const response = await axios.post(`https://api.webshotarchive.com/api/images/${projectId}/update-images`, {
+    find,
+    update,
+  });
+  if (response.status !== 200) {
+    console.log(response.data);
+    throw new Error(`Failed to update images for project ${projectId}`);
+  }
+
+  return response.data;
+};

--- a/packages/scripts/src/lib/util/updateImagesForProject.ts
+++ b/packages/scripts/src/lib/util/updateImagesForProject.ts
@@ -17,7 +17,7 @@ export const updateImagesForProject = async (
   const { find, update } = opts;
   
 
-  const response = await axios.post(`https://api.webshotarchive.com/api/images/${projectId}/update-images`, {
+  const response = await axios.post(`https://api.webshotarchive.com/api/image/update/${projectId}/update-images`, {
     find,
     update,
   });


### PR DESCRIPTION
Because the images are done before the commit, update the images with the commit that matches the release tag.