### PR TITLE
feat(web-ui): add manual wallet support without xpub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Toshi Moto is a watch-only Bitcoin wallet aggregator app for [Umbrel](https://umbrel.com/). It's built as an Nx monorepo with a React frontend and NestJS backend.
+
+## Development Commands
+
+```bash
+# Start development (both frontend and backend)
+pnpm dev
+
+# Start individual services
+pnpm dev:ui          # Frontend only (React/Vite on port 5173)
+pnpm dev:api         # Backend only (NestJS)
+pnpm dev:mongo       # MongoDB database
+
+# Build
+pnpm build           # Build web-ui for production
+pnpm build:api       # Build api for production
+pnpm build:umbrel    # Build web-ui for Umbrel platform
+pnpm build:docker    # Build Docker containers
+
+# Testing
+pnpm test            # Run web-ui tests (Vitest)
+cd apps/web-ui && pnpm test           # Run a single test file with pattern matching
+cd apps/web-ui && pnpm exec vitest run src/path/to/test.spec.ts  # Run specific test
+
+# Storybook
+cd apps/web-ui && pnpm storybook      # Component development (port 6006)
+
+# E2E tests
+cd apps/web-ui && pnpm exec playwright test
+```
+
+## Architecture
+
+```
+apps/
+├── web-ui/          # React 19 frontend (Vite, Tailwind, Redux Toolkit)
+│   ├── src/
+│   │   ├── components/   # React components
+│   │   ├── screens/      # Page components
+│   │   ├── lib/          # Utilities
+│   │   ├── models/       # Data models
+│   │   ├── providers/    # Context providers
+│   │   └── sw.ts         # Service worker (PWA)
+│   └── e2e/              # Playwright tests
+├── api/             # NestJS backend (MongoDB/Mongoose)
+│   └── src/
+│       ├── app/          # NestJS modules
+│       └── middleware/   # Express middleware
+└── docs/            # Documentation site
+
+packages/
+├── toshi-proxy/     # Custom proxy package
+└── scripts/         # Build/deployment scripts
+```
+
+## Tech Stack
+
+**Frontend**: React 19, Vite, Tailwind CSS, Redux Toolkit, React Router, XState, D3
+**Backend**: NestJS, MongoDB, Mongoose, Express
+**Testing**: Vitest (frontend), Jest (backend), Playwright (E2E), Storybook
+**Build**: Nx 21, pnpm, TypeScript (strict mode)
+
+## Key Requirements
+
+- **Always use pnpm** - never npm or yarn
+- **Node 20.11.0** required (enforced via Volta)
+- **Git submodules** - clone with `git clone --recurse-submodule`
+- **Conventional commits** - enforced via commitlint/husky
+- **Docker multi-platform** - builds target ARM64 and AMD64 for Umbrel
+
+## State Management
+
+- Redux Toolkit for global state (`apps/web-ui/src/`)
+- XState for complex state machines
+- Custom Bitcoin library: `@toshimoto821/bitcoinjs`
+
+## Deployment
+
+- Primary target: Umbrel OS
+- Community app store: https://github.com/toshimoto821/toshimoto-app-store
+- Docker containers published to Docker Hub (toshimoto821 namespace)

--- a/apps/web-ui/src/lib/utils.ts
+++ b/apps/web-ui/src/lib/utils.ts
@@ -279,3 +279,21 @@ export const getQueryParams = (search?: string) => {
     return {};
   }
 };
+
+/**
+ * Basic sanity check for Bitcoin address format.
+ * Does minimal validation - the API will provide authoritative validation.
+ */
+export const isValidBitcoinAddress = (address: string): boolean => {
+  if (!address || typeof address !== "string") return false;
+
+  const trimmed = address.trim();
+
+  // Basic length check (shortest valid is ~26 chars, longest ~90)
+  if (trimmed.length < 26 || trimmed.length > 90) return false;
+
+  // Basic character check - alphanumeric only, no spaces or special chars
+  if (!/^[a-zA-Z0-9]+$/.test(trimmed)) return false;
+
+  return true;
+};

--- a/apps/web-ui/src/models/Wallet.ts
+++ b/apps/web-ui/src/models/Wallet.ts
@@ -116,6 +116,18 @@ export class Wallet {
     return this._data.archived || false;
   }
 
+  get walletType() {
+    return this._data.walletType || "xpub";
+  }
+
+  get isManualWallet() {
+    return this.walletType === "manual";
+  }
+
+  get canDeriveAddresses() {
+    return !this.isManualWallet && this.xpubs.length > 0;
+  }
+
   get error() {
     return this._data.meta?.error || null;
   }

--- a/apps/web-ui/src/screens/home/AddressFilterDropdown.tsx
+++ b/apps/web-ui/src/screens/home/AddressFilterDropdown.tsx
@@ -95,67 +95,76 @@ export const AddressFilterDropdown = (props: IAddressFilterDropdown) => {
               </DropdownMenu.Item>
             </DropdownMenu.SubContent>
           </DropdownMenu.Sub>
-          <DropdownMenu.Separator />
-          <DropdownMenu.Sub>
-            <DropdownMenu.SubTrigger>Receive Addresses</DropdownMenu.SubTrigger>
-            <DropdownMenu.SubContent>
-              <DropdownMenu.Item
-                onSelect={() => {
-                  onClickLoadNextAddresses({ change: false });
-                }}
-              >
-                Next 10 Addresses
-              </DropdownMenu.Item>
-              <DropdownMenu.Item
-                onSelect={() => {
-                  onClickLoadNextAddresses({
-                    change: false,
-                    incrementOrDecrement: 1,
-                  });
-                }}
-              >
-                Next Address
-              </DropdownMenu.Item>
+          {/* Only show address derivation options for xpub wallets */}
+          {wallet.canDeriveAddresses && (
+            <>
               <DropdownMenu.Separator />
-              <DropdownMenu.Item
-                onSelect={() => {
-                  onClickTrim({ change: false });
-                }}
-              >
-                Trim
-              </DropdownMenu.Item>
-            </DropdownMenu.SubContent>
-          </DropdownMenu.Sub>
-          <DropdownMenu.Sub>
-            <DropdownMenu.SubTrigger>Change Addresses</DropdownMenu.SubTrigger>
-            <DropdownMenu.SubContent>
-              <DropdownMenu.Item
-                onSelect={() => {
-                  onClickLoadNextAddresses({ change: true });
-                }}
-              >
-                Load Next 10
-              </DropdownMenu.Item>
-              <DropdownMenu.Item
-                onSelect={() => {
-                  onClickLoadNextAddresses({
-                    change: true,
-                    incrementOrDecrement: 1,
-                  });
-                }}
-              >
-                Next Address
-              </DropdownMenu.Item>
-              <DropdownMenu.Separator />
-              <DropdownMenu.Item
-                onSelect={() => {
-                  onClickTrim({ change: true });
-                }}
-              >
-                Trim
-              </DropdownMenu.Item>
-            </DropdownMenu.SubContent>
-          </DropdownMenu.Sub>
+              <DropdownMenu.Sub>
+                <DropdownMenu.SubTrigger>
+                  Receive Addresses
+                </DropdownMenu.SubTrigger>
+                <DropdownMenu.SubContent>
+                  <DropdownMenu.Item
+                    onSelect={() => {
+                      onClickLoadNextAddresses({ change: false });
+                    }}
+                  >
+                    Next 10 Addresses
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    onSelect={() => {
+                      onClickLoadNextAddresses({
+                        change: false,
+                        incrementOrDecrement: 1,
+                      });
+                    }}
+                  >
+                    Next Address
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Separator />
+                  <DropdownMenu.Item
+                    onSelect={() => {
+                      onClickTrim({ change: false });
+                    }}
+                  >
+                    Trim
+                  </DropdownMenu.Item>
+                </DropdownMenu.SubContent>
+              </DropdownMenu.Sub>
+              <DropdownMenu.Sub>
+                <DropdownMenu.SubTrigger>
+                  Change Addresses
+                </DropdownMenu.SubTrigger>
+                <DropdownMenu.SubContent>
+                  <DropdownMenu.Item
+                    onSelect={() => {
+                      onClickLoadNextAddresses({ change: true });
+                    }}
+                  >
+                    Load Next 10
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    onSelect={() => {
+                      onClickLoadNextAddresses({
+                        change: true,
+                        incrementOrDecrement: 1,
+                      });
+                    }}
+                  >
+                    Next Address
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Separator />
+                  <DropdownMenu.Item
+                    onSelect={() => {
+                      onClickTrim({ change: true });
+                    }}
+                  >
+                    Trim
+                  </DropdownMenu.Item>
+                </DropdownMenu.SubContent>
+              </DropdownMenu.Sub>
+            </>
+          )}
 
           <DropdownMenu.Separator />
 

--- a/apps/web-ui/src/screens/home/AddressRow.tsx
+++ b/apps/web-ui/src/screens/home/AddressRow.tsx
@@ -5,6 +5,7 @@ import {
   ChevronRightIcon,
   ChevronDownIcon,
   TriangleUpIcon,
+  TrashIcon,
 } from "@radix-ui/react-icons";
 import { Utxo } from "@models/Utxo";
 import { Transaction } from "@models/Transaction";
@@ -32,6 +33,7 @@ type IAddressRow = {
   dimensions: IDimensions;
   onClickRefresh: ({ address }: { address: Utxo }) => void;
   currency: ICurrency;
+  onClickDelete?: () => void;
 };
 
 export const AddressRow = (prop: IAddressRow) => {
@@ -46,6 +48,7 @@ export const AddressRow = (prop: IAddressRow) => {
     dimensions,
     onClickRefresh,
     currency,
+    onClickDelete,
   } = prop;
 
   const bitcoinNodeUrl = useAppSelector(selectBaseNodeUrl);
@@ -106,7 +109,7 @@ export const AddressRow = (prop: IAddressRow) => {
               </IconButton>
             )}
           </div>
-          <div>
+          <div className="flex items-center gap-2">
             <Button
               title="Refresh"
               variant="outline"
@@ -118,6 +121,11 @@ export const AddressRow = (prop: IAddressRow) => {
                 {address.indexString}
               </Text>
             </Button>
+            {onClickDelete && (
+              <IconButton variant="outline" color="red" onClick={onClickDelete}>
+                <TrashIcon width="14" height="14" />
+              </IconButton>
+            )}
           </div>
           <div className="col-span-3 md:col-span-5 flex items-center justify-end truncate">
             <a


### PR DESCRIPTION
## Summary
- Add ability to create "manual" wallets where users can add individual Bitcoin addresses without an xpub
- Add wallet type selector (Standard vs Manual) in wallet creation dialog
- Add UI to paste and manage individual Bitcoin addresses
- Hide xpub-dependent features (Load Next, Trim) for manual wallets

## Changes
- `wallets.slice.ts` - Add `walletType` field, `addManualAddress`/`removeManualAddress` actions
- `WalletDetails.tsx` - Add radio buttons for wallet type selection
- `WalletDetail.tsx` - Add address input UI for manual wallets
- `AddressRow.tsx` - Add optional delete button prop
- `AddressFilterDropdown.tsx` - Hide xpub-dependent menus for manual wallets
- `Wallet.ts` - Add `isManualWallet`, `canDeriveAddresses` helpers

## Test plan
- [ ] Create a manual wallet with just name and color
- [ ] Add individual Bitcoin addresses to the wallet
- [ ] Verify balance and transactions load correctly
- [ ] Verify "Load Next" and "Trim" buttons are hidden
- [ ] Verify addresses can be removed and indexes reorder
- [ ] Verify existing xpub wallets still work unchanged

Related to #328

🤖 Generated with [Claude Code](https://claude.ai/code)