### PR TITLE
fix(web-ui): pick up new UTXOs to known addresses within the hour (#331)

### DIFF
--- a/apps/web-ui/eslint.config.js
+++ b/apps/web-ui/eslint.config.js
@@ -3,10 +3,12 @@ import nx from "@nx/eslint-plugin";
 import baseConfig from "../../eslint.config.js";
 
 export default [
-  // Playwright rules only apply to the e2e tests, not vitest unit specs.
+  // Playwright rules only apply to the e2e tests, not vitest unit specs. The
+  // `**/` prefix keeps the glob matching whether eslint runs from the project
+  // dir (local) or the repo root (nx in CI).
   {
     ...playwright.configs["flat/recommended"],
-    files: ["e2e/**/*.{ts,tsx,js,jsx}"],
+    files: ["**/e2e/**/*.{ts,tsx,js,jsx}"],
   },
 
   ...baseConfig,

--- a/apps/web-ui/eslint.config.js
+++ b/apps/web-ui/eslint.config.js
@@ -3,7 +3,11 @@ import nx from "@nx/eslint-plugin";
 import baseConfig from "../../eslint.config.js";
 
 export default [
-  playwright.configs["flat/recommended"],
+  // Playwright rules only apply to the e2e tests, not vitest unit specs.
+  {
+    ...playwright.configs["flat/recommended"],
+    files: ["e2e/**/*.{ts,tsx,js,jsx}"],
+  },
 
   ...baseConfig,
   ...nx.configs["flat/react"],

--- a/apps/web-ui/src/lib/hooks/useWallets.ts
+++ b/apps/web-ui/src/lib/hooks/useWallets.ts
@@ -173,7 +173,12 @@ export const useWallets = () => {
         })
       );
     },
-    refreshWallet(walletId: string, ttl = 1000 * 60 * 60 * 24, reset = false) {
+    // Auto-refresh (e.g. opening a wallet) re-fetches address data when the
+    // cache is older than this TTL. Kept to 1 hour so new deposits — including
+    // a second UTXO to an already-known address — show up without waiting up to
+    // a day, while still avoiding a re-fetch on every navigation. Callers that
+    // want to force a refresh pass ttl=0.
+    refreshWallet(walletId: string, ttl = 1000 * 60 * 60, reset = false) {
       dispatch(refreshWallet({ walletId, ttl, reset }));
     },
     refreshAddresses({

--- a/apps/web-ui/src/lib/slices/wallets.slice.spec.ts
+++ b/apps/web-ui/src/lib/slices/wallets.slice.spec.ts
@@ -1,0 +1,106 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { describe, it, expect } from "vitest";
+
+import { walletsReducer, walletsSlice, refreshWallet } from "./wallets.slice";
+import type { Wallet, Address } from "./wallets.slice";
+import { networkReducer } from "./network.slice";
+import type { AppDispatch } from "../store";
+
+const ONE_MINUTE = 1000 * 60;
+
+/**
+ * Builds a minimal store with just the wallets + network reducers. We don't
+ * include the listener/api middleware, so enqueued requests stay in
+ * `network.queue` instead of triggering real fetches — that queue is exactly
+ * what we assert on to know whether a refresh actually re-fetched.
+ */
+const makeStore = () =>
+  configureStore({
+    reducer: {
+      wallets: walletsReducer,
+      network: networkReducer,
+    },
+  });
+
+const seedWallet = (
+  store: ReturnType<typeof makeStore>,
+  refreshedAt: number
+) => {
+  const address: Address = {
+    id: "addr1",
+    index: 0,
+    isChange: false,
+    walletId: "w1",
+    transactions: { ids: [], entities: {} },
+  };
+
+  const wallet: Wallet = {
+    id: "w1",
+    name: "Test Wallet",
+    color: "#ffffff",
+    walletType: "xpub",
+    xpubs: ["xpub-test"],
+    meta: {
+      refreshedAt,
+      change: { lastAddressIndex: 0 },
+      receive: { lastAddressIndex: 0 },
+    },
+    addresses: { ids: ["addr1"], entities: { addr1: address } },
+    addressFilters: { utxoOnly: false },
+  };
+
+  store.dispatch(walletsSlice.actions.upsertWallet(wallet));
+};
+
+const getAddressRequests = (store: ReturnType<typeof makeStore>) => {
+  const { queue } = store.getState().network;
+  return queue.ids
+    .map((id) => queue.entities[id])
+    .filter((item) => item?.action.endpoint === "getAddress");
+};
+
+describe("refreshWallet TTL guard (issue #331)", () => {
+  it("skips re-fetching address data when the cache is younger than the TTL", async () => {
+    const store = makeStore();
+    const refreshedAt = Date.now();
+    seedWallet(store, refreshedAt);
+
+    await (store.dispatch as AppDispatch)(refreshWallet({ walletId: "w1", ttl: ONE_MINUTE }));
+
+    // Fresh cache -> no getAddress enqueued, refreshedAt untouched.
+    expect(getAddressRequests(store)).toHaveLength(0);
+    expect(store.getState().wallets.entities.w1?.meta.refreshedAt).toBe(
+      refreshedAt
+    );
+  });
+
+  it("re-fetches address data once the cache is older than the TTL", async () => {
+    const store = makeStore();
+    const refreshedAt = Date.now() - (ONE_MINUTE + 5000);
+    seedWallet(store, refreshedAt);
+
+    await (store.dispatch as AppDispatch)(refreshWallet({ walletId: "w1", ttl: ONE_MINUTE }));
+
+    // Stale cache -> the wallet's address gets re-queued and refreshedAt bumps.
+    const requests = getAddressRequests(store);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.action.args).toMatchObject({
+      address: "addr1",
+      walletId: "w1",
+    });
+    expect(
+      store.getState().wallets.entities.w1?.meta.refreshedAt
+    ).toBeGreaterThan(refreshedAt);
+  });
+
+  it("always re-fetches when ttl is 0 (manual / forced refresh)", async () => {
+    const store = makeStore();
+    const refreshedAt = Date.now();
+    seedWallet(store, refreshedAt);
+
+    await (store.dispatch as AppDispatch)(refreshWallet({ walletId: "w1", ttl: 0 }));
+
+    // ttl=0 bypasses the guard even with a brand-new cache.
+    expect(getAddressRequests(store)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #331 — _"Not tracking incoming Bitcoin when 2 UTXOs hit the same address."_

The reporter saw a first deposit detected but a **second** deposit to the same address never showed up. This isn't a balance-math or dedup bug — per-address balance already uses `chain_stats.funded_txo_sum - spent_txo_sum` (correct for any number of UTXOs), transactions are keyed by `txid`, and the chart uses `sumVout`. The data just never gets **re-fetched**.

Root cause: opening a wallet auto-refreshes via `actions.refreshWallet(wallet?.id)` (`WalletDetail.tsx`), and the default TTL was **24 hours** (`useWallets.ts`). `refreshWallet` skips the re-fetch when `now - refreshedAt < ttl` (`wallets.slice.ts`). There is no background polling anywhere. So:

1. First deposit is captured during the initial wallet scan.
2. A second deposit to that same address within 24h is masked by the TTL.
3. It stays invisible until 24h pass or the user manually taps refresh (which forces `ttl=0`).

## Fix

- **Lower the auto-refresh TTL from 24h → 1h** (`useWallets.ts`). New transactions to known addresses now appear within the hour on open, while still avoiding a re-fetch on every navigation. Manual refresh still forces an immediate fetch (`ttl=0`).
- **Add the first vitest unit spec for the wallets slice** covering the TTL guard: skips when the cache is fresh, re-fetches when stale, always fetches on forced `ttl=0`.
- **Scope the Playwright eslint config to `e2e/`** — `flat/recommended` was applied repo-wide and flagged `expect()` in the new vitest spec via `playwright/no-standalone-expect`.

## Testing

- `pnpm exec vitest run src/lib/slices/wallets.slice.spec.ts` → 3/3 pass
- `pnpm exec eslint src/lib/slices/wallets.slice.spec.ts` → clean
- `pnpm exec tsc --noEmit` → 0 errors

## Note / possible follow-up

With a 1h TTL, a new deposit can still take up to an hour to surface via the on-open refresh (manual refresh is the immediate escape hatch). A short background poll while a wallet is open would close that gap if near-real-time updates are desired later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)